### PR TITLE
Add docker compose fallback in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,18 @@ PIP=python3 -m pip
 .PHONY: up down seed test fmt report-demo
 
 up:
-	docker-compose -f infrastructure/docker-compose.yml up -d --build
+	@if docker compose version >/dev/null 2>&1; then \
+		docker compose -f infrastructure/docker-compose.yml up -d --build; \
+	else \
+		docker-compose -f infrastructure/docker-compose.yml up -d --build; \
+	fi
 
 down:
-	docker-compose -f infrastructure/docker-compose.yml down
+	@if docker compose version >/dev/null 2>&1; then \
+		docker compose -f infrastructure/docker-compose.yml down; \
+	else \
+		docker-compose -f infrastructure/docker-compose.yml down; \
+	fi
 
 seed:
 	$(PYTHON) backend/app/seed.py


### PR DESCRIPTION
## Summary
- update the Makefile to prefer `docker compose` while falling back to `docker-compose` when necessary

## Testing
- make up *(fails: docker-compose not found in environment)*
- make down *(fails: docker-compose not found in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d60786dd848329b7d1333e450b03b0