### PR TITLE
Improve docker compose detection in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,26 @@
 PYTHON=python3
 PIP=python3 -m pip
 
+DOCKER_COMPOSE := $(shell \
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+        printf '%s' "docker compose"; \
+    elif command -v docker-compose >/dev/null 2>&1; then \
+        printf '%s' "docker-compose"; \
+    else \
+        printf '%s' ""; \
+    fi)
+
+ifeq ($(strip $(DOCKER_COMPOSE)),)
+$(error Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.)
+endif
+
 .PHONY: up down seed test fmt report-demo
 
 up:
-	docker-compose -f infrastructure/docker-compose.yml up -d --build
+	$(DOCKER_COMPOSE) -f infrastructure/docker-compose.yml up -d --build
 
 down:
-	docker-compose -f infrastructure/docker-compose.yml down
+	$(DOCKER_COMPOSE) -f infrastructure/docker-compose.yml down
 
 seed:
 	$(PYTHON) backend/app/seed.py


### PR DESCRIPTION
## Summary
- factor docker compose detection into a reusable Makefile variable that prefers `docker compose` and falls back to `docker-compose`, with a clear error message when neither is available

## Testing
- make up *(fails: Docker Compose not available in environment)*
- make down *(fails: Docker Compose not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d60786dd848329b7d1333e450b03b0