### PR TITLE
Handle docker compose detection at recipe runtime

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,32 @@
 PYTHON=python3
 PIP=python3 -m pip
 
+DOCKER_COMPOSE_DETECT=\
+    if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+        printf '%s' 'docker compose'; \
+    elif command -v docker-compose >/dev/null 2>&1; then \
+        printf '%s' 'docker-compose'; \
+    else \
+        printf '%s' ''; \
+    fi
+
 .PHONY: up down seed test fmt report-demo
 
 up:
-	docker-compose -f infrastructure/docker-compose.yml up -d --build
+	@cmd="$$( $(DOCKER_COMPOSE_DETECT) )"; \
+	if [ -z "$$cmd" ]; then \
+	    printf 'Error: Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.\n' >&2; \
+	    exit 1; \
+	fi; \
+	$$cmd -f infrastructure/docker-compose.yml up -d --build
 
 down:
-	docker-compose -f infrastructure/docker-compose.yml down
+	@cmd="$$( $(DOCKER_COMPOSE_DETECT) )"; \
+	if [ -z "$$cmd" ]; then \
+	    printf 'Error: Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.\n' >&2; \
+	    exit 1; \
+	fi; \
+	$$cmd -f infrastructure/docker-compose.yml down
 
 seed:
 	$(PYTHON) backend/app/seed.py


### PR DESCRIPTION
## Summary
- move docker compose detection logic into a reusable shell snippet executed from docker-dependent targets
- ensure `make up` and `make down` emit a clear error without blocking unrelated targets when Docker Compose is unavailable

## Testing
- make test
- make up *(fails: Docker Compose not available in environment)*
- make down *(fails: Docker Compose not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d60786dd848329b7d1333e450b03b0