### PR TITLE
Prefer docker compose with runtime fallback

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,24 @@ PIP=python3 -m pip
 .PHONY: up down seed test fmt report-demo
 
 up:
-	docker-compose -f infrastructure/docker-compose.yml up -d --build
+	@if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+		docker compose -f infrastructure/docker-compose.yml up -d --build; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+		docker-compose -f infrastructure/docker-compose.yml up -d --build; \
+	else \
+	    printf 'Error: Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.\n' >&2; \
+	    exit 1; \
+	fi
 
 down:
-	docker-compose -f infrastructure/docker-compose.yml down
+	@if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then \
+		docker compose -f infrastructure/docker-compose.yml down; \
+	elif command -v docker-compose >/dev/null 2>&1; then \
+		docker-compose -f infrastructure/docker-compose.yml down; \
+	else \
+	    printf 'Error: Neither "docker compose" nor "docker-compose" is available. Please install Docker Compose.\n' >&2; \
+	    exit 1; \
+	fi
 
 seed:
 	$(PYTHON) backend/app/seed.py


### PR DESCRIPTION
## Summary
- remove the detection helper and call `docker compose` directly from the `up` and `down` recipes
- fall back to `docker-compose` when the Docker Compose plugin is unavailable while retaining the existing error message

## Testing
- make up *(fails: Docker Compose not available in environment)*
- make down *(fails: Docker Compose not available in environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d60786dd848329b7d1333e450b03b0